### PR TITLE
Error literals

### DIFF
--- a/EndlessLauncher/Resources/Literals.Designer.cs
+++ b/EndlessLauncher/Resources/Literals.Designer.cs
@@ -133,11 +133,65 @@ namespace EndlessLauncher.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to This USB stick is in the wrong port. Try a different port..
+        ///   Looks up a localized string similar to Unknown system verification error.
+        /// </summary>
+        public static string error_system_GenericVerificationError {
+            get {
+                return ResourceManager.GetString("error_system_GenericVerificationError", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Insufficient RAM (2GiB of RAM is required).
+        /// </summary>
+        public static string error_system_InsufficientRAM {
+            get {
+                return ResourceManager.GetString("error_system_InsufficientRAM", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to You are not running this program as administrator.
+        /// </summary>
+        public static string error_system_NoAdminRights {
+            get {
+                return ResourceManager.GetString("error_system_NoAdminRights", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Not a 64-bit system.
+        /// </summary>
+        public static string error_system_Not64BitSystem {
+            get {
+                return ResourceManager.GetString("error_system_Not64BitSystem", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to This USB stick is in the wrong port. Try a different port.
         /// </summary>
         public static string error_system_NotUSB30Port {
             get {
                 return ResourceManager.GetString("error_system_NotUSB30Port", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to No USB ports found.
+        /// </summary>
+        public static string error_system_NoUSBPortsFound {
+            get {
+                return ResourceManager.GetString("error_system_NoUSBPortsFound", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Single core processors are not supported.
+        /// </summary>
+        public static string error_system_SingleCoreProcessor {
+            get {
+                return ResourceManager.GetString("error_system_SingleCoreProcessor", resourceCulture);
             }
         }
         
@@ -147,6 +201,33 @@ namespace EndlessLauncher.Resources {
         public static string error_system_UnsupportedFirmware {
             get {
                 return ResourceManager.GetString("error_system_UnsupportedFirmware", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Your version of Windows is not supported (we only support Windows 10).
+        /// </summary>
+        public static string error_system_UnsupportedOS {
+            get {
+                return ResourceManager.GetString("error_system_UnsupportedOS", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to USB device not found.
+        /// </summary>
+        public static string error_system_UsbDeviceNotFound {
+            get {
+                return ResourceManager.GetString("error_system_UsbDeviceNotFound", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to USB port not found.
+        /// </summary>
+        public static string error_system_UsbPortNotFound {
+            get {
+                return ResourceManager.GetString("error_system_UsbPortNotFound", resourceCulture);
             }
         }
         

--- a/EndlessLauncher/Resources/Literals.resx
+++ b/EndlessLauncher/Resources/Literals.resx
@@ -141,11 +141,38 @@
   <data name="error_details" xml:space="preserve">
     <value>Error details</value>
   </data>
+  <data name="error_system_GenericVerificationError" xml:space="preserve">
+    <value>Unknown system verification error</value>
+  </data>
+  <data name="error_system_InsufficientRAM" xml:space="preserve">
+    <value>Insufficient RAM (2GiB of RAM is required)</value>
+  </data>
+  <data name="error_system_NoAdminRights" xml:space="preserve">
+    <value>You are not running this program as administrator</value>
+  </data>
+  <data name="error_system_Not64BitSystem" xml:space="preserve">
+    <value>Not a 64-bit system</value>
+  </data>
   <data name="error_system_NotUSB30Port" xml:space="preserve">
-    <value>This USB stick is in the wrong port. Try a different port.</value>
+    <value>This USB stick is in the wrong port. Try a different port</value>
+  </data>
+  <data name="error_system_NoUSBPortsFound" xml:space="preserve">
+    <value>No USB ports found</value>
+  </data>
+  <data name="error_system_SingleCoreProcessor" xml:space="preserve">
+    <value>Single core processors are not supported</value>
   </data>
   <data name="error_system_UnsupportedFirmware" xml:space="preserve">
     <value>Legacy BIOS is not supported</value>
+  </data>
+  <data name="error_system_UnsupportedOS" xml:space="preserve">
+    <value>Your version of Windows is not supported (we only support Windows 10)</value>
+  </data>
+  <data name="error_system_UsbDeviceNotFound" xml:space="preserve">
+    <value>USB device not found</value>
+  </data>
+  <data name="error_system_UsbPortNotFound" xml:space="preserve">
+    <value>USB port not found</value>
   </data>
   <data name="error_unknown" xml:space="preserve">
     <value>Unknown error</value>

--- a/EndlessLauncher/model/Errors.cs
+++ b/EndlessLauncher/model/Errors.cs
@@ -41,7 +41,6 @@ namespace EndlessLauncher.model
         UsbPortNotFound,
         NotUSB30Port,
         NoUSBPortsFound,
-        UnsupportedResolution
     };
 
     public class EndlessErrorEventArgs<T> : EventArgs


### PR DESCRIPTION
I didn't add literals for Firmware setup errors since they are too cryptic, probably we can find a way to make those readable.