### PR TITLE
Open forum rather than Zendesk support site

### DIFF
--- a/EndlessLauncher/ViewModel/IncompatibilityViewModel.cs
+++ b/EndlessLauncher/ViewModel/IncompatibilityViewModel.cs
@@ -84,7 +84,7 @@ namespace EndlessLauncher.ViewModel
                     ?? (supportRelayCommand = new RelayCommand(
                     () =>
                     {
-                        Utils.OpenUrl("https://support.endlessm.com/hc/en-us", null);
+                        Utils.OpenUrl("https://community.endlessos.com/c/endless-key/67", null);
                     }));
             }
         }


### PR DESCRIPTION
We are moving to a model where the community forum is our primary
support channel. Adjust the support link to point to a newly-created
Endless Key category on the forum.