### PR TITLE
Remove launcher code which requires admin rights

### DIFF
--- a/EndlessLauncher/app.manifest
+++ b/EndlessLauncher/app.manifest
@@ -16,7 +16,7 @@
             Remove this element if your application requires this virtualization for backwards
             compatibility.
         -->
-        <requestedExecutionLevel  level="requireAdministrator" uiAccess="false" />
+        <requestedExecutionLevel  level="asInvoker" uiAccess="false" />
       </requestedPrivileges>
     </security>
   </trustInfo>

--- a/EndlessLauncher/utility/LauncherShortcuts.cs
+++ b/EndlessLauncher/utility/LauncherShortcuts.cs
@@ -1,8 +1,4 @@
 ﻿using System.Diagnostics;
-using System.Linq;
-using Microsoft.Win32;
-using WindowsFirewallHelper;
-using WindowsFirewallHelper.FirewallAPIv2.Rules;
 
 namespace EndlessLauncher.utility
 {
@@ -12,15 +8,6 @@ namespace EndlessLauncher.utility
 
         public static Process OpenKiwix()
         {
-            var vcRuntimeInstallerPath = System.IO.Path.Combine(
-                GetExecutableDirectory(),
-                ".kiwix-windows",
-                "vc_redist.x64.exe"
-            );
-
-            // TODO: Wait asynchronously while disabling the Kiwix button
-            Utils.OpenUrl(vcRuntimeInstallerPath, "/install /quiet /norestart").WaitForExit();
-
             var kiwixExePath = System.IO.Path.Combine(
                 GetExecutableDirectory(),
                 ".kiwix-windows",
@@ -49,28 +36,6 @@ namespace EndlessLauncher.utility
                 ".kolibri-windows",
                 "Kolibri.exe"
             );
-
-            var existingFwRule = FirewallManager.Instance.Rules.SingleOrDefault(fwRule => {
-                if (!(fwRule is StandardRuleWin8))
-                {
-                    return false;
-                }
-
-                var win8Rule = (StandardRuleWin8)fwRule;
-                return win8Rule.Name == FIREWALL_KOLIBRI_RULE_NAME && win8Rule.ApplicationName == kolibriExePath;
-            });
-
-            if (existingFwRule == null)
-            {
-                var fwRule = FirewallManager.Instance.CreateApplicationRule(
-                    FirewallManager.Instance.GetProfile().Type,
-                    FIREWALL_KOLIBRI_RULE_NAME,
-                    FirewallAction.Allow,
-                    kolibriExePath
-                );
-                fwRule.Direction = FirewallDirection.Inbound;
-                FirewallManager.Instance.Rules.Add(fwRule);
-            }
 
             return Utils.OpenUrl(kolibriExePath, "");
         }


### PR DESCRIPTION
Instead, Kiwix is expected to bundle the needed runtime DLLs and Kolibri is expected to work as expected regardless of firewall exceptions.

https://phabricator.endlessm.com/T31909